### PR TITLE
Switch Win32 pipes to PIPE_WAIT

### DIFF
--- a/src/event/event_windows.c
+++ b/src/event/event_windows.c
@@ -277,6 +277,9 @@ _dispatch_pipe_monitor_thread(void *context)
 		char cBuffer[1];
 		DWORD dwNumberOfBytesTransferred;
 		OVERLAPPED ov = {0};
+		// Block on a 0-byte read; this will only resume when data is
+		// available in the pipe. The pipe must be PIPE_WAIT or this thread
+		// will spin.
 		BOOL bSuccess = ReadFile(hPipe, cBuffer, /* nNumberOfBytesToRead */ 0,
 				&dwNumberOfBytesTransferred, &ov);
 		DWORD dwBytesAvailable;


### PR DESCRIPTION
Fixes https://github.com/swiftlang/swift-corelibs-libdispatch/issues/820 . There is a lot of useful context in this issue, which I will partially reproduce below.

I have an alternate PR that fixes this problem in a more fundamental way, but slightly changes the requirements of libdispatch: https://github.com/swiftlang/swift-corelibs-libdispatch/pull/854.

* In https://github.com/swiftlang/swift-corelibs-libdispatch/pull/781, the pipe was changed from `PIPE_WAIT` to `PIPE_NOWAIT` to achieve POSIX-like `O_NONBLOCK` semantics, as attempting to write a large buffer would cause the dispatch queue thread to block long enough to hit a time out.
* The Windows pipe synchronization thread, `_dispatch_pipe_monitor_thread`, uses a blocking 0-byte read as a synchronization mechanism to signal to the actual reader threads that there is data waiting in the pipe. Of course, for this to work, the read must actually be blocking. With a `PIPE_NOWAIT` pipe, the Read will not block, causing the thread to spin endlessly and constantly wake the actual reader thread to perform 0 byte reads. This spinning thread is the root source of the problem in this issue.

Switching the pipe back to `PIPE_WAIT` potentially resurfaces the blocking writes problem, however I think that https://github.com/swiftlang/swift-corelibs-libdispatch/pull/796 (which was a follow-up PR to fix a problem with the `PIPE_NOWAIT` implementation) also resolves the blocking write problem _in practice_ but not necessarily in all cases.

https://github.com/swiftlang/swift-corelibs-libdispatch/pull/796 attempts to bound the max size of the write to avoid blocking the dispatch thread:

https://github.com/swiftlang/swift-corelibs-libdispatch/blob/0c38954e0033f4ef112fc2b6d8244c798dce30da/src/io.c#L2516-L2528
* We first check the `WriteQuotaAvailable` of the pipe (which is the size of the pipe's buffer - the total amount of space queued to be read - the bytes already present in the output buffer), and use this as an initial upper bound.
* If `WriteQuotaAvailable == 0`, this implies we either have a reader that has requested a full buffer's worth of data from the pipe, and so we bound by the size of the pipe's buffer (`OutboundQuota`) OR the output buffer is already full.
* In the first case, the write will not block because the data fits into the pipe's outbound buffer.
* In the second case (the output buffer is already full), the write will block until data is drained from the pipe by a reader.

So if nothing is actively reading the data, the queue will be blocked from making progress. However, I have been unable to trigger this case in practice. If there is no reader on the pipe, `WriteFile` will fail quickly. From what I could grok from the libdispatch code, the pipe synchronization mechanism will always have a reader waiting on some I/O Completion Port that will quickly resume when data in the pipe is available to be read.

I am _reasonably confident_ in this conclusion, but because I was never able to reproduce the original hanging write with the write-bounding logic removed, I have been unable to verify that the write hang issue cannot occur in practice with this PR. I tested this under many different scenarios, both realistic and pathological, but never encountered this particular issue.

With this PR though, I can verify that the spinning thread is gone, and programs which rely on libdispatch exhibit considerably better CPU performance (namely sourcekit-lsp).

cc @compnerd 