### PR TITLE
[Don't merge] Lower timeout to force failure to check for log output

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -176,7 +176,7 @@ foreach(test ${DISPATCH_C_TESTS})
                   dispatch_${test}.c)
 endforeach()
 
-set_tests_properties(dispatch_io_pipe PROPERTIES TIMEOUT 15)
+set_tests_properties(dispatch_io_pipe PROPERTIES TIMEOUT 1)
 set_tests_properties(dispatch_io_pipe_close PROPERTIES TIMEOUT 5)
 
 # test dispatch API for various C/CXX language variants


### PR DESCRIPTION
This is just to help check if a change to Swift CI will report verbose libdispatch test failures