### PR TITLE
swift: use `internal` instead of `@_implementationOnly`

### DIFF
--- a/src/swift/Block.swift
+++ b/src/swift/Block.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import CDispatch
-@_implementationOnly import _DispatchOverlayShims
+internal import _DispatchOverlayShims
 
 public struct DispatchWorkItemFlags : OptionSet, RawRepresentable {
 	public let rawValue: UInt

--- a/src/swift/Data.swift
+++ b/src/swift/Data.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import CDispatch
-@_implementationOnly import _DispatchOverlayShims
+internal import _DispatchOverlayShims
 
 public struct DispatchData : RandomAccessCollection {
 	public typealias Iterator = DispatchDataIterator

--- a/src/swift/Queue.swift
+++ b/src/swift/Queue.swift
@@ -13,7 +13,7 @@
 // dispatch/queue.h
 
 import CDispatch
-@_implementationOnly import _DispatchOverlayShims
+internal import _DispatchOverlayShims
 
 public final class DispatchSpecificKey<T> {
 	public init() {}

--- a/src/swift/Source.swift
+++ b/src/swift/Source.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import CDispatch
-@_implementationOnly import _DispatchOverlayShims
+internal import _DispatchOverlayShims
 #if os(Windows)
 import WinSDK
 #endif

--- a/src/swift/Wrapper.swift
+++ b/src/swift/Wrapper.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import CDispatch
-@_implementationOnly import _DispatchOverlayShims
+internal import _DispatchOverlayShims
 
 // This file contains declarations that are provided by the
 // importer via Dispatch.apinote when the platform has Objective-C support


### PR DESCRIPTION
Prefer to use the new `internal import` functionality over the reserved `@_implementationOnly` attribute.