### PR TITLE
build: bring `config.h.in` into sync with checked in copy

### DIFF
--- a/cmake/config.h.in
+++ b/cmake/config.h.in
@@ -257,3 +257,6 @@
 
 /* Define if using Darwin $NOCANCEL */
 #cmakedefine __DARWIN_NON_CANCELABLE
+
+/* Define to 1 if you have the `strlcpy` function. */
+#cmakedefine01 HAVE_STRLCPY


### PR DESCRIPTION
`HAVE_STRLCPY` was added to the static configuration but not the dynamic configuration. Update the template for this.