### PR TITLE
Set CMP0157 to OLD for Android

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,16 @@
-
 cmake_minimum_required(VERSION 3.26...3.29)
+
+if(POLICY CMP0157)
+    if(CMAKE_HOST_SYSTEM_NAME STREQUAL Windows AND CMAKE_SYSTEM_NAME STREQUAL Android)
+        # CMP0157 causes libdispatch to fail to compile when targetting
+        # Android on Windows due to swift-driver not being present during the
+        # toolchain build. Disable it for now.
+        cmake_policy(SET CMP0157 OLD)
+    else()
+        # New Swift build model: improved incremental build performance and LSP support
+        cmake_policy(SET CMP0157 NEW)
+    endif()
+endif()
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules)
 


### PR DESCRIPTION
There is no early swift-driver build for the Windows toolchain. As a result, libdispatch fails to build properly when CMP0157 is set to NEW due to object files not being generated.

This sets CMP0157 to OLD when targetting Android until the early swift-driver is available on Windows.