### PR TITLE
dispatch: split `DISPATCH_EXPORT` and prepare for static linking

### DIFF
--- a/dispatch/base.h
+++ b/dispatch/base.h
@@ -186,16 +186,24 @@
 # endif
 #endif
 
-#if defined(_WIN32)
-#if defined(__DISPATCH_BUILDING_DISPATCH__)
-#define DISPATCH_EXPORT DISPATCH_EXTERN __declspec(dllexport)
+#if defined(dispatch_STATIC)
+# if __GNUC__
+#   define DISPATCH_EXPORT DISPATCH_EXTERN __attribute__((__visibility__("hidden")))
+# else
+#   define DISPATCH_EXPORT DISPATCH_EXTERN
+# endif
 #else
-#define DISPATCH_EXPORT DISPATCH_EXTERN __declspec(dllimport)
-#endif
-#elif __GNUC__
-#define DISPATCH_EXPORT DISPATCH_EXTERN __attribute__((visibility("default")))
-#else
-#define DISPATCH_EXPORT DISPATCH_EXTERN
+# if defined(_WIN32)
+#   if defined(dispatch_EXPORT) || defined(__DISPATCH_BUILDING_DISPATCH__)
+#     define DISPATCH_EXPORT DISPATCH_EXTERN __declspec(dllexport)
+#   else
+#     define DISPATCH_EXPORT DISPATCH_EXTERN __declspec(dllimport)
+#   endif
+# elif __GNUC__
+#   define DISPATCH_EXPORT DISPATCH_EXTERN __attribute__((__visibility__("default")))
+# else
+#   define DISPATCH_EXPORT DISPATCH_EXTERN
+# endif
 #endif
 
 #if __GNUC__

--- a/dispatch/base.h
+++ b/dispatch/base.h
@@ -178,24 +178,24 @@
 #endif
 #endif
 
+#ifndef DISPATCH_EXTERN
+# if defined(__cplusplus)
+#   define DISPATCH_EXTERN extern "C"
+# else
+#   define DISPATCH_EXTERN extern
+# endif
+#endif
+
 #if defined(_WIN32)
 #if defined(__DISPATCH_BUILDING_DISPATCH__)
-#if defined(__cplusplus)
-#define DISPATCH_EXPORT extern "C" __declspec(dllexport)
+#define DISPATCH_EXPORT DISPATCH_EXTERN __declspec(dllexport)
 #else
-#define DISPATCH_EXPORT extern __declspec(dllexport)
-#endif
-#else
-#if defined(__cplusplus)
-#define DISPATCH_EXPORT extern "C" __declspec(dllimport)
-#else
-#define DISPATCH_EXPORT extern __declspec(dllimport)
-#endif
+#define DISPATCH_EXPORT DISPATCH_EXTERN __declspec(dllimport)
 #endif
 #elif __GNUC__
-#define DISPATCH_EXPORT extern __attribute__((visibility("default")))
+#define DISPATCH_EXPORT DISPATCH_EXTERN __attribute__((visibility("default")))
 #else
-#define DISPATCH_EXPORT extern
+#define DISPATCH_EXPORT DISPATCH_EXTERN
 #endif
 
 #if __GNUC__


### PR DESCRIPTION
This change accomplishes two items:
1. splits out a new `DISPATCH_EXTERN` macro to decorate with `extern` or `extern "C"` based on the compilation mode (C vs C++).
2. enables a new configuration macro (`dispatch_STATIC`) that allows building with libdispatch for static linking. The default remains dynamic linking.

The motivation for `DISPATCH_EXTERN` is primarily being able to concisely define `DISPATCH_EXPORT`. This follows the naming scheme that most other Apple frameworks use (e.g. UIKit, Foundation, etc).

The change to introduce support for static linking is motivated by Windows. With the gradual roll out of static linking of the runtime, it would be convenient to be able to statically link dispatch into a fully sealed Swift program. Doing so requires building libdispatch without the `__declspec(dllexport)` and `__declspec(dllimport)` attributes on Windows. Similarly, it would be unfortunate to have dispatch's ABI be subsumed by a client library and have it participate in dynamic linking.

The user is responsible for defining `dispatch_STATIC` when using a static copy of libdispatch. This allows the default to remain dynamic linking (which is the preferred style on Darwin and Windows).