### PR TITLE
build: various adjustments for the runtime libraries

### DIFF
--- a/src/BlocksRuntime/CMakeLists.txt
+++ b/src/BlocksRuntime/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-add_library(BlocksRuntime
+add_library(BlocksRuntime SHARED
   data.c
   runtime.c)
 if(WIN32)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-add_library(dispatch
+add_library(dispatch SHARED
   allocator.c
   apply.c
   benchmark.c


### PR DESCRIPTION
Adjust the build in three specific manners:
1. hoist BlocksRuntime inclusion to the top level, it is not part of libdispatch
2. only support a shared library build of libdispatch as the project conflates libdispatch and libclosure, and `BUILD_SHARED_LIBS` only permits us to globally control that behaviour
3. adjust the libclosure build to include the necessary flags to support building against a static libclosure

After a side discussion between @rokhinip, @mikeash, @akmorrison, and myself (@compnerd), we decided that we should only support a dynamically linked libdispatch for the C portion of the runtime. While we have not yet decided on the direction for libclosure, in order to support the build of a static and dynamic libclosure, we pin the libdispatch build to a shared only build rather than just letting the build system control this via the `BUILD_SHARED_LIBS` global flag.