### PR TITLE
Install nested Swift modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,7 +117,6 @@ include(DispatchAppleOptions)
 include(DispatchSanitization)
 include(DispatchCompilerWarnings)
 include(DTrace)
-include(SwiftSupport)
 
 # NOTE(abdulras) this is the CMake supported way to control whether we generate
 # shared or static libraries.  This impacts the behaviour of `add_library` in

--- a/cmake/modules/SwiftSupport.cmake
+++ b/cmake/modules/SwiftSupport.cmake
@@ -1,3 +1,5 @@
+include_guard()
+
 if(NOT dispatch_MODULE_TRIPLE)
   set(module_triple_command "${CMAKE_Swift_COMPILER}" -print-target-info)
   if(CMAKE_Swift_COMPILER_TARGET)

--- a/cmake/modules/SwiftSupport.cmake
+++ b/cmake/modules/SwiftSupport.cmake
@@ -1,45 +1,28 @@
-
-# Returns the current achitecture name in a variable
-#
-# Usage:
-#   get_swift_host_arch(result_var_name)
-#
-# If the current architecture is supported by Swift, sets ${result_var_name}
-# with the sanitized host architecture name derived from CMAKE_SYSTEM_PROCESSOR.
-function(get_swift_host_arch result_var_name)
-  if("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "x86_64")
-    set("${result_var_name}" "x86_64" PARENT_SCOPE)
-  elseif ("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "AArch64|aarch64|arm64|ARM64")
-    if(APPLE)
-      set("${result_var_name}" "arm64" PARENT_SCOPE)
-    else()
-      set("${result_var_name}" "aarch64" PARENT_SCOPE)
-    endif()
-  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "ppc64")
-    set("${result_var_name}" "powerpc64" PARENT_SCOPE)
-  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "ppc64le")
-    set("${result_var_name}" "powerpc64le" PARENT_SCOPE)
-  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "s390x")
-    set("${result_var_name}" "s390x" PARENT_SCOPE)
-  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "armv6l")
-    set("${result_var_name}" "armv6" PARENT_SCOPE)
-  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "armv7-a")
-    set("${result_var_name}" "armv7" PARENT_SCOPE)
-  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "armv7l")
-    set("${result_var_name}" "armv7" PARENT_SCOPE)
-  elseif("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "amd64|AMD64")
-    if(WIN32)
-      set("${result_var_name}" "x86_64" PARENT_SCOPE)
-    else()
-      set("${result_var_name}" "amd64" PARENT_SCOPE)
-    endif()
-  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "IA64")
-    set("${result_var_name}" "itanium" PARENT_SCOPE)
-  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "x86")
-    set("${result_var_name}" "i686" PARENT_SCOPE)
-  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "i686")
-    set("${result_var_name}" "i686" PARENT_SCOPE)
-  else()
-    message(FATAL_ERROR "Unrecognized architecture on host system: ${CMAKE_SYSTEM_PROCESSOR}")
+if(NOT dispatch_MODULE_TRIPLE)
+  set(module_triple_command "${CMAKE_Swift_COMPILER}" -print-target-info)
+  if(CMAKE_Swift_COMPILER_TARGET)
+    list(APPEND module_triple_command -target ${CMAKE_Swift_COMPILER_TARGET})
   endif()
+  execute_process(COMMAND ${module_triple_command} OUTPUT_VARIABLE target_info_json)
+
+  string(JSON module_triple GET "${target_info_json}" "target" "moduleTriple")
+  set(dispatch_MODULE_TRIPLE "${module_triple}" CACHE STRING "Triple used to install swiftmodule files")
+  mark_as_advanced(dispatch_MODULE_TRIPLE)
+
+  message(CONFIGURE_LOG "Swift module triple: ${module_triple}")
+endif()
+
+function(install_swift_module target)
+  get_target_property(module ${target} Swift_MODULE_NAME)
+  if(NOT module)
+    set(module ${target})
+  endif()
+  install(
+    FILES $<TARGET_PROPERTY:${target},Swift_MODULE_DIRECTORY>/${module}.swiftdoc
+    DESTINATION ${INSTALL_TARGET_DIR}/${module}.swiftmodule
+    RENAME ${dispatch_MODULE_TRIPLE}.swiftdoc)
+  install(
+    FILES $<TARGET_PROPERTY:${target},Swift_MODULE_DIRECTORY>/${module}.swiftmodule
+    DESTINATION ${INSTALL_TARGET_DIR}/${module}.swiftmodule
+    RENAME ${dispatch_MODULE_TRIPLE}.swiftmodule)
 endfunction()

--- a/src/swift/CMakeLists.txt
+++ b/src/swift/CMakeLists.txt
@@ -36,11 +36,7 @@ if(NOT APPLE AND NOT WIN32)
   set_target_properties(swiftDispatch PROPERTIES INSTALL_RPATH "$ORIGIN")
 endif()
 
-get_swift_host_arch(swift_arch)
-install(FILES
-  ${CMAKE_CURRENT_BINARY_DIR}/swift/Dispatch.swiftmodule
-  ${CMAKE_CURRENT_BINARY_DIR}/swift/Dispatch.swiftdoc
-  DESTINATION ${INSTALL_TARGET_DIR}/${swift_arch})
+install_swift_module(swiftDispatch)
 set_property(GLOBAL APPEND PROPERTY DISPATCH_EXPORTS swiftDispatch)
 install(TARGETS swiftDispatch
   EXPORT dispatchExports

--- a/src/swift/CMakeLists.txt
+++ b/src/swift/CMakeLists.txt
@@ -1,3 +1,5 @@
+include(SwiftSupport)
+
 if(HAVE_OBJC)
   add_library(DispatchStubs STATIC
     DispatchStubs.m)


### PR DESCRIPTION
Migrating to using the nested swiftmodule structure. This avoids needing to compute the architecture in the CMake script, using the compiler to tell us what the triple should be, making the build more robust. This also means that we can drop the architecture-specific subdirectory and install the dispatch modules alongside the swiftmodules for the other projects.

Note: We will need changes to the Windows installer scripts to reflect the new layout.