### PR TITLE
[Tests] Fix Dispatch tests to work in container environments.

### DIFF
--- a/tests/dispatch_apply.c
+++ b/tests/dispatch_apply.c
@@ -21,6 +21,7 @@
 #include <dispatch/dispatch.h>
 #include <stdio.h>
 #if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
+#include <pthread.h>
 #include <unistd.h>
 #ifdef __ANDROID__
 #include <linux/sysctl.h>
@@ -83,6 +84,14 @@ static void test_apply_contended(dispatch_queue_t dq)
 	uint32_t activecpu;
 #if defined(__linux__) || defined(__OpenBSD__) || defined(__FreeBSD__)
 	activecpu = (uint32_t)sysconf(_SC_NPROCESSORS_ONLN);
+
+#if defined(__linux__) && __USE_GNU
+        cpu_set_t cpuset;
+        if (pthread_getaffinity_np(pthread_self(),
+                                   sizeof(cpu_set_t),
+                                   &cpuset) == 0)
+          activecpu = (uint32_t)CPU_COUNT(&cpuset);
+#endif
 #elif defined(_WIN32)
 	SYSTEM_INFO si;
 	GetSystemInfo(&si);

--- a/tests/dispatch_workqueue.c
+++ b/tests/dispatch_workqueue.c
@@ -1,6 +1,11 @@
 #include <bsdtests.h>
 #include "dispatch_test.h"
 
+#if defined(__linux__)
+// For pthread_getaffinity_np()
+#include <pthread.h>
+#endif
+
 struct test_context {
 	uint32_t ncpu;
 	int flag;
@@ -35,6 +40,15 @@ activecpu(void)
         uint32_t activecpu;
 #if defined(__linux__) || defined(__OpenBSD__)
         activecpu = (uint32_t)sysconf(_SC_NPROCESSORS_ONLN);
+
+#if defined(__linux__) && __USE_GNU
+        cpu_set_t cpuset;
+        if (pthread_getaffinity_np(pthread_self(),
+                                   sizeof(cpu_set_t),
+                                   &cpuset) == 0)
+          activecpu = (uint32_t)CPU_COUNT(&cpuset);
+#endif
+
 #elif defined(_WIN32)
         SYSTEM_INFO si;
         GetSystemInfo(&si);


### PR DESCRIPTION
We need to use `pthread_getaffinity_np()` to get the active core count; using `sysconf()` will tell us about the underlying machine, which may have many more cores than the container in which we are executing.

rdar://152301793