### PR TITLE
Silence signedness change through implicit conversion error

### DIFF
--- a/src/event/event_epoll.c
+++ b/src/event/event_epoll.c
@@ -89,7 +89,9 @@ DISPATCH_ALWAYS_INLINE
 static inline uint32_t
 _dispatch_muxnote_armed_events(dispatch_muxnote_t dmn)
 {
-	return dmn->dmn_events & ~dmn->dmn_disarmed_events;
+  uint32_t events = dmn->dmn_events;
+  uint16_t disarmed_events = dmn->dmn_disarmed_events;
+  return events & ~(uint32_t)disarmed_events;
 }
 
 DISPATCH_ALWAYS_INLINE


### PR DESCRIPTION
The error pops up when using the rebranch Clang (stable/20250402):

```
/home/build-user/swift-corelibs-libdispatch/src/event/event_epoll.c:92:27: error: implicit conversion changes signedness: 'int' to 'uint32_t' (aka 'unsigned int') [-Werror,-Wsign-conversion]
92 |         return dmn->dmn_events & ~dmn->dmn_disarmed_events;
   |                                ~ ^~~~~~~~~~~~~~~~~~~~~~~~~
```