### PR TITLE
build: adjust the build to support building statically on Windows

### DIFF
--- a/dispatch/base.h
+++ b/dispatch/base.h
@@ -194,7 +194,7 @@
 # endif
 #else
 # if defined(_WIN32)
-#   if defined(dispatch_EXPORT) || defined(__DISPATCH_BUILDING_DISPATCH__)
+#   if defined(dispatch_EXPORTS)
 #     define DISPATCH_EXPORT DISPATCH_EXTERN __declspec(dllexport)
 #   else
 #     define DISPATCH_EXPORT DISPATCH_EXTERN __declspec(dllimport)

--- a/src/BlocksRuntime/CMakeLists.txt
+++ b/src/BlocksRuntime/CMakeLists.txt
@@ -7,8 +7,11 @@ if(WIN32)
     BlocksRuntime.def)
 
   if(NOT BUILD_SHARED_LIBS)
-    target_compile_definitions(BlocksRuntime PRIVATE
+    target_compile_definitions(BlocksRuntime PUBLIC
       BlocksRuntime_STATIC)
+    target_compile_options(BlocksRuntime PUBLIC
+      "$<$<COMPILE_LANGUAGE:C,CXX>:SHELL:$<$<BOOL:${MSVC}>:-Xclang >-static-libclosure>"
+      $<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -static-libclosure>)
   endif()
 endif()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -92,6 +92,10 @@ target_include_directories(dispatch PUBLIC
 target_include_directories(dispatch PRIVATE
   ${PROJECT_SOURCE_DIR}/private)
 
+if(NOT BUILD_SHARED_LIBS)
+  target_compile_definitions(dispatch PUBLIC
+    dispatch_STATIC)
+endif()
 if(WIN32)
   target_compile_definitions(dispatch PRIVATE
     _CRT_NONSTDC_NO_WARNINGS

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -23,6 +23,8 @@ add_library(bsdtests
             STATIC
               bsdtests.c
               dispatch_test.c)
+target_link_libraries(bsdtests PUBLIC
+  dispatch)
 target_include_directories(bsdtests
                            PRIVATE
                              ${CMAKE_CURRENT_BINARY_DIR}


### PR DESCRIPTION
This adds the necessary build support required to build libdispatch and BlocksRuntime (libclosure) statically on Windows as well.