### PR TITLE
build: correct linking to static libdispatch on Windows

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -95,6 +95,8 @@ target_include_directories(dispatch PRIVATE
 if(NOT BUILD_SHARED_LIBS)
   target_compile_definitions(dispatch PUBLIC
     dispatch_STATIC)
+  target_compile_options(dispatch PUBLIC
+    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -Ddispatch_STATIC>")
 endif()
 if(WIN32)
   target_compile_definitions(dispatch PRIVATE


### PR DESCRIPTION
When building against the static libdispatch, we need to inform the dispatch headers that the library will be linked statically via `-Ddispatch_STATIC`. Wire this up onto the dispatch library to allow `swiftDispatch` to properly propagate that flag.