### PR TITLE
[6.2.1] build: Use new 16 KB page alignment on 64-bit Android

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -274,6 +274,7 @@ check_symbol_exists(__printflike "bsd/sys/cdefs.h" HAVE_PRINTFLIKE)
 
 if(CMAKE_SYSTEM_NAME STREQUAL Android)
   set(ENABLE_DTRACE_DEFAULT OFF)
+  add_link_options("LINKER:-z,max-page-size=16384")
 endif()
 
 if(CMAKE_SYSTEM_NAME STREQUAL FreeBSD)


### PR DESCRIPTION
__Explanation:__ Add a linker flag for the upcoming 16 KB page support in Android.

__Scope:__ Only affects Android

__Issue:__ None

__Original PR:__ #893

__Risk:__ None, only affects Android

__Testing:__ Passed trunk and release/6.2 CI and confirmed locally that this fixed the alignment

__Reviewer:__ @compnerd

@swift-ci test