### PR TITLE
Enable Windows ARM64/ARM64EC

### DIFF
--- a/src/firehose/firehose_buffer.c
+++ b/src/firehose/firehose_buffer.c
@@ -37,10 +37,10 @@
 
 #define DISPATCH_INTERNAL_CRASH(ac, msg) ({ panic(msg); __builtin_trap(); })
 
-#if defined(__x86_64__) || defined(__i386__)
+#if (defined(__x86_64__) || defined(__i386__)) && !defined(__arm64ec__)
 #define dispatch_hardware_pause() __asm__("pause")
 #elif (defined(__arm__) && defined(_ARM_ARCH_7) && defined(__thumb__)) || \
-		defined(__arm64__)
+		defined(__arm64__) || defined(__arm64ec__)
 #define dispatch_hardware_pause() __asm__("yield")
 #define dispatch_hardware_wfe()   __asm__("wfe")
 #else

--- a/src/shims/atomic_sfb.h
+++ b/src/shims/atomic_sfb.h
@@ -27,7 +27,7 @@
 #ifndef __DISPATCH_SHIMS_ATOMIC_SFB__
 #define __DISPATCH_SHIMS_ATOMIC_SFB__
 
-#if defined(__x86_64__) || defined(__i386__)
+#if (defined(__x86_64__) || defined(__i386__)) && !defined(__arm64ec__)
 
 // Returns UINT_MAX if all the bits in p were already set.
 DISPATCH_ALWAYS_INLINE

--- a/src/shims/time.h
+++ b/src/shims/time.h
@@ -49,7 +49,7 @@ typedef enum {
 
 void _dispatch_time_init(void);
 
-#if defined(__i386__) || defined(__x86_64__) || !HAVE_MACH_ABSOLUTE_TIME
+#if ((defined(__x86_64__) || defined(__i386__)) && !defined(__arm64ec__)) || !HAVE_MACH_ABSOLUTE_TIME
 #define DISPATCH_TIME_UNIT_USES_NANOSECONDS 1
 #else
 #define DISPATCH_TIME_UNIT_USES_NANOSECONDS 0

--- a/src/shims/tsd.h
+++ b/src/shims/tsd.h
@@ -355,7 +355,7 @@ _dispatch_cpu_number(void)
 {
 #if __has_include(<os/tsd.h>)
 	return _os_cpu_number();
-#elif defined(__x86_64__) || defined(__i386__)
+#elif (defined(__x86_64__) || defined(__i386__)) && !defined(__arm64ec__)
 	struct { uintptr_t p1, p2; } p;
 	__asm__("sidt %[p]" : [p] "=&m" (p));
 	return (unsigned int)(p.p1 & 0xfff);

--- a/src/shims/yield.h
+++ b/src/shims/yield.h
@@ -122,10 +122,10 @@ void *_dispatch_wait_for_enqueuer(void **ptr);
 #pragma mark -
 #pragma mark dispatch_hardware_pause
 
-#if defined(__x86_64__) || defined(__i386__)
+#if (defined(__x86_64__) || defined(__i386__)) && !defined(__arm64ec__)
 #define dispatch_hardware_pause() __asm__("pause")
 #elif (defined(__arm__) && defined(_ARM_ARCH_7) && defined(__thumb__)) || \
-		defined(__arm64__)
+		defined(__arm64__) || defined(__arm64ec__)
 #define dispatch_hardware_pause() __asm__("yield")
 #define dispatch_hardware_wfe()   __asm__("wfe")
 #else

--- a/tests/Foundation/bench.mm
+++ b/tests/Foundation/bench.mm
@@ -148,7 +148,7 @@ print_result2(uint64_t s, const char *str)
 }
 #endif
 
-#if defined(__i386__) || defined(__x86_64__)
+#if (defined(__x86_64__) || defined(__i386__)) && !defined(__arm64ec__)
 static inline uint64_t
 rdtsc(void)
 {
@@ -229,7 +229,7 @@ main(void)
 
 	kr = mach_timebase_info(&tbi);
 	assert(kr == 0);
-#if defined(__i386__) || defined(__x86_64__)
+#if (defined(__x86_64__) || defined(__i386__)) && !defined(__arm64ec__)
 	assert(tbi.numer == tbi.denom); /* This will fail on PowerPC. */
 #endif
 
@@ -269,7 +269,7 @@ main(void)
 	print_result2(s, "mach_absolute_time():");
 #endif
 
-#if defined(__i386__) || defined(__x86_64__)
+#if (defined(__x86_64__) || defined(__i386__)) && !defined(__arm64ec__)
 	s = mach_absolute_time();
 	for (i = cnt; i; i--) {
 		rdtsc();
@@ -382,7 +382,7 @@ main(void)
 	}
 	print_result(s, "raw 'nop':");
 
-#if defined(__i386__) || defined(__x86_64__)
+#if (defined(__x86_64__) || defined(__i386__)) && !defined(__arm64ec__)
 	s = mach_absolute_time();
 	for (i = cnt; i; i--) {
 		__asm__ __volatile__ ("pause");
@@ -639,7 +639,7 @@ main(void)
 	for (i = cnt; i; i--) {
 		while (!__sync_bool_compare_and_swap(&global, 0, 1)) {
 			do {
-#if defined(__i386__) || defined(__x86_64__)
+#if (defined(__x86_64__) || defined(__i386__)) && !defined(__arm64ec__)
 				__asm__ __volatile__ ("pause");
 #elif defined(__arm__) && defined _ARM_ARCH_7
 				__asm__ __volatile__ ("yield");

--- a/tests/dispatch_select.c
+++ b/tests/dispatch_select.c
@@ -133,7 +133,6 @@ stage2(void)
 		size_t buffer_size = 500*1024*sizeof(char);
 		char *buffer = malloc(buffer_size);
 		ssize_t sz = dispatch_test_fd_read(fd, buffer, buffer_size);
-		free(buffer);
 		actual += sz;
 		if (sz < (ssize_t)(buffer_size))
 		{
@@ -142,6 +141,7 @@ stage2(void)
 			test_long("EOF", sz, 0);
 			dispatch_source_cancel(source);
 		}
+		free(buffer);
 	});
 
 	dispatch_source_set_cancel_handler(source, ^{


### PR DESCRIPTION
This PR allows building for ARM64 and ARM64EC.

ARM64 worked out of the box, but the `dispatch_select` test failed, due to a use-after-free. For some reason this didn't affect other platforms/architectures, but writing to the `buffer` variable caused a memory fault on native Windows ARM64.

ARM64EC has a few define checks added, to ensure x64 ASM calls aren't run.

Tested using VS2022 and LLVM 21.1.2.