### PR TITLE
Use relative kqueue deadlines for BSD uptime and monotonic timers

### DIFF
--- a/src/event/event_kevent.c
+++ b/src/event/event_kevent.c
@@ -68,10 +68,22 @@ DISPATCH_STATIC_GLOBAL(struct dispatch_muxnote_bucket_s _dispatch_sources[DSL_HA
 #define DISPATCH_NOTE_CLOCK_UPTIME    0
 #endif
 
+#if defined(__FreeBSD__) || defined(__OpenBSD__)
+// BSD NOTE_ABSTIME deadlines use CLOCK_REALTIME.
+#define DISPATCH_NOTE_ABSOLUTE_WALL      NOTE_ABSOLUTE
+#define DISPATCH_NOTE_ABSOLUTE_MONOTONIC 0
+#define DISPATCH_NOTE_ABSOLUTE_UPTIME    0
+#else
+#define DISPATCH_NOTE_ABSOLUTE_WALL      NOTE_ABSOLUTE
+#define DISPATCH_NOTE_ABSOLUTE_MONOTONIC NOTE_ABSOLUTE
+#define DISPATCH_NOTE_ABSOLUTE_UPTIME    NOTE_ABSOLUTE
+#endif
+
 static const uint32_t _dispatch_timer_index_to_fflags[] = {
 #define DISPATCH_TIMER_FFLAGS_INIT(kind, qos, note) \
 	[DISPATCH_TIMER_INDEX(DISPATCH_CLOCK_##kind, DISPATCH_TIMER_QOS_##qos)] = \
-			DISPATCH_NOTE_CLOCK_##kind | NOTE_ABSOLUTE | NOTE_LEEWAY | (note)
+			DISPATCH_NOTE_CLOCK_##kind | DISPATCH_NOTE_ABSOLUTE_##kind | \
+			NOTE_LEEWAY | (note)
 	DISPATCH_TIMER_FFLAGS_INIT(WALL, NORMAL, 0),
 	DISPATCH_TIMER_FFLAGS_INIT(UPTIME, NORMAL, 0),
 	DISPATCH_TIMER_FFLAGS_INIT(MONOTONIC, NORMAL, 0),
@@ -2414,6 +2426,10 @@ _dispatch_event_loop_timer_arm(dispatch_timer_heap_t dth, uint32_t tidx,
 	}
 #if !NOTE_ABSOLUTE
 	target = range.delay;
+#elif defined(__FreeBSD__) || defined(__OpenBSD__)
+	if (clock != DISPATCH_CLOCK_WALL) {
+		target -= _dispatch_time_now_cached(clock, nows);
+	}
 #endif
 
 	_dispatch_event_loop_timer_program(dth, tidx, target, range.leeway,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -140,6 +140,10 @@ set(DISPATCH_C_TESTS
     io_pipe_close
     select)
 
+if(UNIX)
+  list(APPEND DISPATCH_C_TESTS timer_idle)
+endif()
+
 # Tests that usually pass, but occasionally fail.
 # Excluded by default for purposes of Swift CI
 if(EXTENDED_TEST_SUITE)

--- a/tests/dispatch_timer_idle.c
+++ b/tests/dispatch_timer_idle.c
@@ -1,0 +1,150 @@
+/*
+ * This source file is part of the Swift.org open source project
+ *
+ * Copyright (c) 2026 Apple Inc. and the Swift project authors
+ *
+ * Licensed under Apache License v2.0 with Runtime Library Exception
+ *
+ * See https://swift.org/LICENSE.txt for license information
+ * See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+ *
+ */
+
+#include <dispatch/dispatch.h>
+
+#include <bsdtests.h>
+#include "dispatch_test.h"
+
+#include <errno.h>
+#include <stdatomic.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/resource.h>
+#include <time.h>
+
+#define OBSERVATION_SECONDS 0.25
+#define MAX_IDLE_CPU_RATIO 0.20
+
+static _Atomic int timer_fired;
+static volatile uint64_t spin_sink;
+
+static void
+monotonic_now(struct timespec *value)
+{
+	if (clock_gettime(CLOCK_MONOTONIC, value) != 0) {
+		perror("clock_gettime");
+		exit(EXIT_FAILURE);
+	}
+}
+
+static double
+seconds_between(struct timespec start, struct timespec end)
+{
+	return (double)(end.tv_sec - start.tv_sec) +
+		(double)(end.tv_nsec - start.tv_nsec) / (double)NSEC_PER_SEC;
+}
+
+static double
+timeval_seconds(struct timeval value)
+{
+	return (double)value.tv_sec +
+		(double)value.tv_usec / (double)USEC_PER_SEC;
+}
+
+static double
+process_cpu_seconds(void)
+{
+	struct rusage usage;
+
+	if (getrusage(RUSAGE_SELF, &usage) != 0) {
+		perror("getrusage");
+		exit(EXIT_FAILURE);
+	}
+	return timeval_seconds(usage.ru_utime) + timeval_seconds(usage.ru_stime);
+}
+
+static double
+measure_busy_cpu_ratio(void)
+{
+	struct timespec wall_start, wall_now;
+	double cpu_start, cpu_end;
+
+	monotonic_now(&wall_start);
+	cpu_start = process_cpu_seconds();
+	do {
+		spin_sink++;
+		monotonic_now(&wall_now);
+	} while (seconds_between(wall_start, wall_now) < OBSERVATION_SECONDS);
+	cpu_end = process_cpu_seconds();
+
+	return (cpu_end - cpu_start) / seconds_between(wall_start, wall_now);
+}
+
+static void
+unexpected_timer_fire(void *context)
+{
+	(void)context;
+	atomic_store_explicit(&timer_fired, 1, memory_order_relaxed);
+}
+
+static void
+observe_idle_timer(double *wall_seconds, double *cpu_seconds)
+{
+	struct timespec wall_start, wall_end;
+	struct timespec remaining = {
+		.tv_sec = 0,
+		.tv_nsec = (long)(OBSERVATION_SECONDS * (double)NSEC_PER_SEC),
+	};
+	dispatch_source_t timer;
+	double cpu_start;
+	int sleep_result;
+
+	timer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0,
+			dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0));
+	test_ptr_notnull("dispatch_source_create", timer);
+	dispatch_source_set_event_handler_f(timer, unexpected_timer_fire);
+	dispatch_source_set_timer(timer,
+			dispatch_time(DISPATCH_TIME_NOW, 3600 * NSEC_PER_SEC),
+			DISPATCH_TIME_FOREVER, 0);
+	dispatch_resume(timer);
+
+	monotonic_now(&wall_start);
+	cpu_start = process_cpu_seconds();
+	do {
+		sleep_result = nanosleep(&remaining, &remaining);
+	} while (sleep_result == -1 && errno == EINTR);
+	if (sleep_result != 0) {
+		perror("nanosleep");
+		exit(EXIT_FAILURE);
+	}
+	*cpu_seconds = process_cpu_seconds() - cpu_start;
+	monotonic_now(&wall_end);
+	*wall_seconds = seconds_between(wall_start, wall_end);
+
+	dispatch_source_cancel(timer);
+	dispatch_release(timer);
+}
+
+int
+main(void)
+{
+	double busy_cpu_ratio, idle_wall_seconds, idle_cpu_seconds;
+	double idle_cpu_ratio, relative_cpu_ratio;
+
+	dispatch_test_start("Dispatch idle timer CPU usage");
+
+	busy_cpu_ratio = measure_busy_cpu_ratio();
+	observe_idle_timer(&idle_wall_seconds, &idle_cpu_seconds);
+	idle_cpu_ratio = idle_cpu_seconds / idle_wall_seconds;
+	relative_cpu_ratio = idle_cpu_ratio / busy_cpu_ratio;
+
+	fprintf(stderr, "idle=%f busy=%f relative=%f\n",
+			idle_cpu_ratio, busy_cpu_ratio, relative_cpu_ratio);
+	test_long("timer fired", atomic_load_explicit(&timer_fired,
+			memory_order_relaxed), 0);
+	test_double_less_than("idle timer CPU ratio", relative_cpu_ratio,
+			MAX_IDLE_CPU_RATIO);
+	test_stop();
+	return 0;
+}


### PR DESCRIPTION
## Summary

On FreeBSD and OpenBSD, `NOTE_NSECONDS | NOTE_ABSTIME` uses a realtime absolute deadline. libdispatch supplied boot-relative values for uptime and monotonic timers, so kqueue treated them as expired and repeatedly woke and re-armed the timer.

This change:
- keeps wall-clock timers on the absolute path;
- programs uptime and monotonic timers as relative delays on FreeBSD and OpenBSD;
- adds a public-API regression test that detects CPU use while a far-future timer is idle.

## Validation

Tested on FreeBSD 15.1 with Swift 6.3-dev:

- current `main`: the new idle timer test reports a relative CPU ratio of approximately `0.74` and fails;
- patched: the test reports approximately `0.0006` and passes;
- full default C test suite: `25/25` passed;
- the original Hummingbird workload no longer produces the kqueue re-arm loop.

Runtime validation was performed on FreeBSD. The OpenBSD change follows the same existing `NOTE_ABSTIME` clock semantics.

## Shared clock helper experiment

I also tested adding `kern.boottime` to `_dispatch_uptime` and `_dispatch_monotonic_time` instead of changing the kqueue backend. It stopped the timer loop, but introduced two regressions in local testing:
- `dispatch_time(DISPATCH_TIME_NOW, ...)` increased from approximately `43 ns` to `565 ns` per call because the shared path performs a `sysctl`;
- after a test shim advanced only the returned `kern.boottime` value by one hour, a pre-existing 200 ms monotonic deadline expired in `0.032 ms`. The backend-local version expired in `200.142 ms`.

FreeBSD adjusts `kern.boottime` when system time is stepped and after resume, so this revision leaves the shared uptime and monotonic clock helpers unchanged.

## Update history

- 2026-05-22: added the initial backend-local fix and FreeBSD workload reproduction.
- 2026-07-15: rebased onto current `main`, added the idle CPU regression test, reduced the backend comments, and evaluated the `kern.boottime` alternative.
