### PR TITLE
Fix unused-but-set-global error

### DIFF
--- a/src/queue.c
+++ b/src/queue.c
@@ -6546,7 +6546,9 @@ _dispatch_pthread_root_queue_dispose(dispatch_queue_global_t dq,
 #pragma mark -
 #pragma mark dispatch_runloop_queue
 
+#ifndef __linux__
 DISPATCH_STATIC_GLOBAL(bool _dispatch_program_is_probably_callback_driven);
+#endif
 
 #if DISPATCH_COCOA_COMPAT
 DISPATCH_STATIC_GLOBAL(dispatch_once_t _dispatch_main_q_handle_pred);
@@ -6680,7 +6682,9 @@ _dispatch_runloop_queue_handle_init(void *ctxt)
 #endif
 	_dispatch_runloop_queue_set_handle(dq, handle);
 
+#ifndef __linux__
 	_dispatch_program_is_probably_callback_driven = true;
+#endif
 }
 
 static void
@@ -7148,7 +7152,9 @@ dispatch_main(void)
 	if (pthread_main_np()) {
 #endif
 		_dispatch_object_debug(&_dispatch_main_q, "%s", __func__);
+#ifndef __linux__
 		_dispatch_program_is_probably_callback_driven = true;
+#endif
 		_dispatch_ktrace0(ARIADNE_ENTER_DISPATCH_MAIN_CODE);
 #ifdef __linux__
 		// On Linux, if the main thread calls pthread_exit, the process becomes a zombie.


### PR DESCRIPTION
This is blocking Swift rebranch builds.
```
/home/build-user/swift-corelibs-libdispatch/src/queue.c:6549:29: error: variable '_dispatch_program_is_probably_callback_driven' set but not used [-Werror,-Wunused-but-set-global]
 6549 | DISPATCH_STATIC_GLOBAL(bool _dispatch_program_is_probably_callback_driven);
```

Clang 23 suddenly caught this on the Swift CI builders. This global is read only under `#ifndef __linux__`.