### PR TITLE
feat: prepare shared code for cooperative single-threaded event backends

### DIFF
--- a/src/queue.c
+++ b/src/queue.c
@@ -6877,6 +6877,13 @@ _dispatch_main_queue_update_priority_from_thread(void)
 	}
 }
 
+#endif // DISPATCH_COCOA_COMPAT
+#if DISPATCH_COCOA_COMPAT || defined(__wasi__)
+// Shared between the CFRunLoop callback path (DISPATCH_COCOA_COMPAT) and a
+// cooperative single-threaded drain, which owns the thread-bound main
+// queue's drain lock for the lifetime of the program. The runloop-handle
+// initialization and the thread-QoS override propagation are runloop/Darwin
+// machinery and compile only for COCOA_COMPAT.
 static void
 _dispatch_main_queue_drain(dispatch_queue_main_t dq)
 {
@@ -6898,8 +6905,10 @@ _dispatch_main_queue_drain(dispatch_queue_main_t dq)
 				" from the wrong thread");
 	}
 
+#if DISPATCH_COCOA_COMPAT
 	dispatch_once_f(&_dispatch_main_q_handle_pred, dq,
 			_dispatch_runloop_queue_handle_init);
+#endif
 
 	// <rdar://problem/23256682> hide the frame chaining when CFRunLoop
 	// drains the main runloop, as this should not be observable that way
@@ -6908,12 +6917,14 @@ _dispatch_main_queue_drain(dispatch_queue_main_t dq)
 
 	pthread_priority_t pp = _dispatch_get_priority();
 	dispatch_priority_t pri = _dispatch_priority_from_pp(pp);
-	dispatch_qos_t qos = _dispatch_priority_qos(pri);
 	voucher_t voucher = _voucher_copy();
 
+#if DISPATCH_COCOA_COMPAT
+	dispatch_qos_t qos = _dispatch_priority_qos(pri);
 	if (unlikely(qos != _dispatch_priority_qos(dq->dq_priority))) {
 		_dispatch_main_queue_update_priority_from_thread();
 	}
+#endif
 	dispatch_priority_t old_dbp = _dispatch_set_basepri(pri);
 	_dispatch_set_basepri_override_qos(DISPATCH_QOS_SATURATED);
 
@@ -6936,6 +6947,8 @@ _dispatch_main_queue_drain(dispatch_queue_main_t dq)
 	_dispatch_force_cache_cleanup();
 	_dispatch_perfmon_end_notrace();
 }
+#endif // DISPATCH_COCOA_COMPAT || defined(__wasi__)
+#if DISPATCH_COCOA_COMPAT
 
 static bool
 _dispatch_runloop_queue_drain_one(dispatch_lane_t dq)


### PR DESCRIPTION
## Summary

This PR moves one function, `_dispatch_main_queue_drain`, out of `DISPATCH_COCOA_COMPAT` and under a separate guard. It makes no functional change on any current platform.

## Context

WebAssembly (`wasm32-wasip1`) runs libdispatch on a single thread. The port registers with the host event loop as an event source, like libdispatch registers with CFRunLoop on Darwin. A poke asks the host for one later callback. The host then invokes libdispatch, and `_dispatch_main_queue_drain` drains the main queue.

An earlier revision of this PR added hook macros around eight critical sections. Those hooks supported a drain-on-poke model that ran work on the caller stack. The port dropped that model, and this PR dropped the hooks. The complete port lives on our fork as one reviewable branch: [PassiveLogic/swift-corelibs-libdispatch#3](https://github.com/PassiveLogic/swift-corelibs-libdispatch/pull/3).

## What changes

`_dispatch_main_queue_drain` moves under a guard of its own. The two runloop-only steps stay under `DISPATCH_COCOA_COMPAT`: the runloop-handle initialization, and the thread-QoS override propagation. The guard also names `defined(__wasi__)`. The new `__wasi__` arm adds no compiled code in this PR.

## Why this is safe

- On Darwin, `DISPATCH_COCOA_COMPAT` retains both runloop-only steps. Darwin builds the same code as before.
- On Linux, neither version compiles this code, as before.

## What we ask from reviewers

The public macOS CMake build of this repository does not configure, so we cannot compile the `DISPATCH_COCOA_COMPAT` path ourselves. We ask a committer to trigger `@swift-ci please test`. We also ask which CI configuration compiles the `DISPATCH_COCOA_COMPAT` path.
