### PR TITLE
dispatch: declare Windows static link dependencies

### DIFF
--- a/src/block.cpp
+++ b/src/block.cpp
@@ -30,6 +30,11 @@
 
 #include "internal.h"
 
+// WORKAROUND swiftlang/swift#91648
+#if defined(_WIN32) && defined(dispatch_STATIC)
+#pragma comment(lib, "BlocksRuntime.lib")
+#endif
+
 // NOTE: this file must not contain any atomic operations
 
 #if DISPATCH_DEBUG && DISPATCH_BLOCK_PRIVATE_DATA_DEBUG

--- a/src/data.c
+++ b/src/data.c
@@ -20,6 +20,11 @@
 
 #include "internal.h"
 
+// WORKAROUND swiftlang/swift#91648
+#if defined(_WIN32) && defined(dispatch_STATIC)
+#pragma comment(lib, "BlocksRuntime.lib")
+#endif
+
 /*
  * Dispatch data objects are dispatch objects with standard retain/release
  * memory management. A dispatch data object either points to a number of other

--- a/src/event/event_windows.c
+++ b/src/event/event_windows.c
@@ -19,6 +19,12 @@
  */
 
 #include "internal.h"
+
+// WORKAROUND swiftlang/swift#91648
+#if defined(_WIN32) && defined(dispatch_STATIC)
+#pragma comment(lib, "WS2_32.lib")
+#endif
+
 #if DISPATCH_EVENT_BACKEND_WINDOWS
 
 static HANDLE hPort = NULL;

--- a/src/event/workqueue.c
+++ b/src/event/workqueue.c
@@ -20,6 +20,11 @@
 
 #include "internal.h"
 
+// WORKAROUND swiftlang/swift#91648
+#if defined(_WIN32) && defined(dispatch_STATIC)
+#pragma comment(lib, "AdvAPI32.lib")
+#endif
+
 #if DISPATCH_USE_INTERNAL_WORKQUEUE
 
 #if defined(_WIN32)

--- a/src/init.c
+++ b/src/init.c
@@ -24,6 +24,12 @@
 // NOTE: this file must not contain any atomic operations
 
 #include "internal.h"
+
+// WORKAROUND swiftlang/swift#91648
+#if defined(_WIN32) && defined(dispatch_STATIC)
+#pragma comment(lib, "BlocksRuntime.lib")
+#endif
+
 #if __linux__
 #include <linux/limits.h> // for PATH_MAX
 #endif

--- a/src/io.c
+++ b/src/io.c
@@ -20,6 +20,13 @@
 
 #include "internal.h"
 
+// WORKAROUND swiftlang/swift#91648
+#if defined(_WIN32) && defined(dispatch_STATIC)
+#pragma comment(lib, "BlocksRuntime.lib")
+#pragma comment(lib, "ShLwApi.lib")
+#pragma comment(lib, "WS2_32.lib")
+#endif
+
 #if defined(__FreeBSD__)
 #include <fcntl.h>
 #endif

--- a/src/queue.c
+++ b/src/queue.c
@@ -19,6 +19,13 @@
  */
 
 #include "internal.h"
+
+// WORKAROUND swiftlang/swift#91648
+#if defined(_WIN32) && defined(dispatch_STATIC)
+#pragma comment(lib, "BlocksRuntime.lib")
+#pragma comment(lib, "ole32.lib")
+#endif
+
 #if HAVE_MACH
 #include "protocol.h" // _dispatch_send_wakeup_runloop_thread
 #endif

--- a/src/shims/lock.c
+++ b/src/shims/lock.c
@@ -20,6 +20,13 @@
 
 #include "internal.h"
 
+// WORKAROUND swiftlang/swift#91648
+#if defined(_WIN32) && defined(dispatch_STATIC)
+#pragma comment(lib, "BlocksRuntime.lib")
+#pragma comment(lib, "WinMM.lib")
+#pragma comment(lib, "synchronization.lib")
+#endif
+
 #if TARGET_OS_MAC
 dispatch_static_assert(DLOCK_LOCK_DATA_CONTENTION ==
 		ULF_WAIT_WORKQ_DATA_CONTENTION);

--- a/src/source.c
+++ b/src/source.c
@@ -20,6 +20,11 @@
 
 #include "internal.h"
 
+// WORKAROUND swiftlang/swift#91648
+#if defined(_WIN32) && defined(dispatch_STATIC)
+#pragma comment(lib, "BlocksRuntime.lib")
+#endif
+
 static void _dispatch_source_handler_free(dispatch_source_refs_t ds, long kind);
 
 #pragma mark -

--- a/src/transform.c
+++ b/src/transform.c
@@ -20,6 +20,12 @@
 
 #include "internal.h"
 
+// WORKAROUND swiftlang/swift#91648
+#if defined(_WIN32) && defined(dispatch_STATIC)
+#pragma comment(lib, "BlocksRuntime.lib")
+#pragma comment(lib, "WS2_32.lib")
+#endif
+
 #ifdef __APPLE__
 #include <libkern/OSByteOrder.h>
 #elif __linux__


### PR DESCRIPTION
Static Windows dispatch objects now declare their own link dependencies through /DEFAULTLIB pragmas in internal.h, so every extracted archive member carries the same closure.

The seven-library set is this repository's CMake link interface (BlocksRuntime, AdvAPI32, ShLwApi, WS2_32, WinMM, synchronization) plus ole32 from the measured static-consumer closure. DLL builds resolved these imports at their own link, static consumers have to supply them at the final link.

Companion to swiftlang/swift#91668 per the discussion there, with swiftlang/swift#91648 as context.

## Validation

End-to-end rides on the next candidate toolchain build. This is the library set that made the swiftlang/swift#91648 reproducer link and run in swiftlang/swift-driver#2174.
