### PR TITLE
Fix the @param name on dispatch_barrier_async_and_wait

### DIFF
--- a/private/workloop_private.h
+++ b/private/workloop_private.h
@@ -391,7 +391,7 @@ dispatch_async_and_wait_f(dispatch_queue_t queue,
  * The target dispatch queue to which the block is submitted.
  * The result of passing NULL in this parameter is undefined.
  *
- * @param work
+ * @param block
  * The application-defined block to invoke on the target queue.
  * The result of passing NULL in this parameter is undefined.
  */


### PR DESCRIPTION
The prose right under the tag already says "the application-defined block", and the argument is a dispatch_block_t named block. Looks like the tag was carried over from dispatch_barrier_async_and_wait_f above it, which does take work.
